### PR TITLE
[Feat] openpose 모델 output keypoint 수 18개로 수정 #4

### DIFF
--- a/model/pytorch_openpose/extract_keypoint.py
+++ b/model/pytorch_openpose/extract_keypoint.py
@@ -33,7 +33,6 @@ def main_openpose(target_buffer_dir, output_buffer_dir):
 
     # body_estimation foreward
     candidate, subset = body_estimation(oriImg)
-    print('candidate len : ',len(candidate))
 
     while True:
         if len(candidate) == 18:
@@ -45,7 +44,6 @@ def main_openpose(target_buffer_dir, output_buffer_dir):
             candidate.append(np.array([-1.0, -1.0, 0.0, -1.0]))
             candidate = np.array(candidate)
 
-    print('candidate len : ',len(candidate))
     json_dict = {
         'keypoints' : candidate.tolist()
     }


### PR DESCRIPTION
## Motivation
- openpose model의 keypoint개수가 18개가 아닐 경우 ladi-vton 모델에서 에러 발생(weight의 크기가 맞지 않음)

## Key Changes
- extract_keypoint.py에서 수정
- keypoint의 개수가 18개가 아닐 경우  keypoint의 개수를 18개로 맞춰준다.

## To Reviewer
- PR 남겨요! 확인 부탁드려요.

## Issue Tags
- Fixed: #4
